### PR TITLE
Add parsing of conf/privilege file

### DIFF
--- a/spkrepo/utils.py
+++ b/spkrepo/utils.py
@@ -151,6 +151,13 @@ class SPK(object):
                         except UnicodeDecodeError:
                             raise SPKParseError('Wrong conf/PKG_CONX encoding')
                         self.conf_conflicts = json.dumps({s: {k: v for k, v in c.items(s)} for s in c.sections()})
+                    if 'conf/privilege' in names:
+                        c = ConfigParser()
+                        try:
+                            c.read_string(spk.extractfile('conf/privilege').read().decode('utf-8'))
+                        except UnicodeDecodeError:
+                            raise SPKParseError('Wrong conf/privilege encoding')
+                        self.conf_conflicts = json.dumps({s: {k: v for k, v in c.items(s)} for s in c.sections()})
                     if self.conf_dependencies is None and self.conf_conflicts is None:
                         raise SPKParseError('Empty conf folder')
 


### PR DESCRIPTION
Can't upload packages with `privilege` file unless it's parsed, and we need that for DSM6 users.

There's at least one other file introduced with DSM6 (`resource` to create shared folders), maybe others...I'll have to check. We're not using those atm.