### PR TITLE
Increase package name length constraint

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -148,7 +148,7 @@ class Screenshot(db.Model):
     # Columns
     id = db.Column(db.Integer, primary_key=True)
     package_id = db.Column(db.Integer, db.ForeignKey('package.id'), nullable=False)
-    path = db.Column(db.Unicode(100), nullable=False)
+    path = db.Column(db.Unicode(200), nullable=False)
 
     # Relationhips
     package = db.relationship('Package', back_populates='screenshots')


### PR DESCRIPTION
Because of longer list of `x86_64` architecture aliases, these package
publication fails with http 502 error code.

Applied on existing production database:
alter table build alter column path TYPE varchar(200);