### PR TITLE
Allow firmware versions up to 6 digits

### DIFF
--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -20,7 +20,7 @@ from ..utils import SPK
 api = Blueprint('api', __name__)
 
 # regexes
-firmware_re = re.compile(r'^(?P<version>\d\.\d)-(?P<build>\d{3,4})$')
+firmware_re = re.compile(r'^(?P<version>\d\.\d)-(?P<build>\d{3,6})$')
 version_re = re.compile(r'^(?P<upstream_version>.*)-(?P<version>\d+)$')
 
 


### PR DESCRIPTION
Since DSM 6, firmware version is 5 digit length, which prevents
packages built for this version to be published.